### PR TITLE
Fix: Ensure Pomodoro dark mode card background visibility

### DIFF
--- a/pomodoro.html
+++ b/pomodoro.html
@@ -193,6 +193,7 @@
                         document.documentElement.className = themeKey; 
                         if (themeKey === 'dark') {
                             document.documentElement.className = 'dark'; // Ensure html tag gets dark class
+                            document.documentElement.style.backgroundColor = 'transparent'; // ADD THIS LINE
                             document.body.style.backgroundColor = 'transparent'; // CRITICAL CHANGE
                             document.body.style.color = '#d1d5db'; // text-gray-300
                         } else { // Light theme


### PR DESCRIPTION
This commit addresses an issue where the parent card background in `index.html` would disappear when the Pomodoro widget (in an iframe) loaded its dark theme.

The fix involves ensuring that both the `<html>` and `<body>` elements within the `pomodoro.html` iframe are explicitly set to have a transparent background when the dark theme is active. This prevents any background color from the iframe document itself from obscuring the intended card background styled by the parent page (`index.html`).

- Modified `applyTheme` in `pomodoro.html` to set `document.documentElement.style.backgroundColor = 'transparent';` in addition to `document.body.style.backgroundColor = 'transparent';` for the dark theme.
- Verified that `WIDGET_THEMES.dark.bg` in `pomodoro.html` remains `'bg-transparent'` for the `#app-widget` div.
- Re-confirmed CSS for `.pomodoro-widget-container` in `index.html` is correct.